### PR TITLE
drivers: ieee802154: nrf5: Remove TX modes when not supported

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -174,9 +174,16 @@ drop:
 
 static enum ieee802154_hw_caps nrf5_get_capabilities(const struct device *dev)
 {
-	return IEEE802154_HW_FCS | IEEE802154_HW_FILTER |
-	       IEEE802154_HW_CSMA | IEEE802154_HW_2_4_GHZ |
-	       IEEE802154_HW_TX_RX_ACK | IEEE802154_HW_ENERGY_SCAN |
+	return IEEE802154_HW_FCS |
+	       IEEE802154_HW_FILTER |
+#if !defined(CONFIG_NRF_802154_SL_OPENSOURCE) && \
+    !defined(CONFIG_NRF_802154_SER_HOST)
+	       IEEE802154_HW_CSMA |
+	       IEEE802154_HW_TXTIME |
+#endif
+	       IEEE802154_HW_2_4_GHZ |
+	       IEEE802154_HW_TX_RX_ACK |
+	       IEEE802154_HW_ENERGY_SCAN |
 	       IEEE802154_HW_SLEEP_TO_TX;
 }
 
@@ -392,6 +399,8 @@ static int nrf5_tx(const struct device *dev,
 	case IEEE802154_TX_MODE_CCA:
 		ret = nrf_802154_transmit_raw(nrf5_radio->tx_psdu, true);
 		break;
+#if !defined(CONFIG_NRF_802154_SL_OPENSOURCE) && \
+    !defined(CONFIG_NRF_802154_SER_HOST)
 	case IEEE802154_TX_MODE_CSMA_CA:
 		nrf_802154_transmit_csma_ca_raw(nrf5_radio->tx_psdu);
 		break;
@@ -412,6 +421,7 @@ static int nrf5_tx(const struct device *dev,
 						 nrf_802154_channel_get());
 		break;
 	}
+#endif
 	default:
 		NET_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;


### PR DESCRIPTION
Remove TXTIME, TXTIME_CCA, CSMA_CA capabilities and their calls when
they are not supported by selected drivers. Add TXTIME flag in
get_capabilites function.

Signed-off-by: Pawel Kwiek <Pawel Kwiek>